### PR TITLE
Fix utils imports

### DIFF
--- a/src/components/ui/badge.jsx
+++ b/src/components/ui/badge.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/utils"
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none",

--- a/src/components/ui/checkbox.jsx
+++ b/src/components/ui/checkbox.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { CheckIcon } from "@radix-ui/react-icons"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/utils"
 
 const Checkbox = React.forwardRef(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root

--- a/src/components/ui/separator.jsx
+++ b/src/components/ui/separator.jsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/utils"
 
 const Separator = React.forwardRef(({
   className,


### PR DESCRIPTION
## Summary
- update badge/separator/checkbox components to reference `@/utils`

## Testing
- `pnpm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68404dac18e48323b3f373b29e137c5d