### PR TITLE
Fix badge import

### DIFF
--- a/src/views/ArchivesView.jsx
+++ b/src/views/ArchivesView.jsx
@@ -1,7 +1,8 @@
 
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
-import { Archive, Trophy, Crown, Trash2, Badge } from 'lucide-react'
+import { Archive, Trophy, Crown, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge.jsx'
 
 function ArchivesView({ archives, setArchives, setCurrentView }) {
   const supprimerArchive = (index) => {


### PR DESCRIPTION
## Summary
- correct path for `Badge` import in `ArchivesView`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684404e9350c8323a9dd495ac3c277c5