### PR TITLE
Fix unused imports and clean linter warnings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,19 +4,19 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.j
 import { Input } from '@/components/ui/input.jsx'
 import { Label } from '@/components/ui/label.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
-import { Separator } from '@/components/ui/separator.jsx'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
-import { Users, Trophy, Play, Settings, Archive, Crown, Plus, Edit, Trash2, UserCheck, Medal } from 'lucide-react'
+import { Users, Trophy, Play, Settings, Archive, Crown, Plus, Edit, Trash2, Medal } from 'lucide-react'
 import './App.css'
 import AdminView from '@/views/AdminView.jsx'
 import JoueurView from '@/views/JoueurView.jsx'
 import ArchivesView from '@/views/ArchivesView.jsx'
+import HomeView from '@/views/HomeView.jsx'
 import PartieCard from '@/components/PartieCard.jsx'
 
 
 function App() {
   const [currentView, setCurrentView] = useState('home')
-  const [isArbitre, setIsArbitre] = useState(false)
+  const [, setIsArbitre] = useState(false)
   const [password, setPassword] = useState('')
   const [joueurs, setJoueurs] = useState([])
   const [concours, setConcours] = useState(null)
@@ -28,7 +28,6 @@ function App() {
   const [nombreParties, setNombreParties] = useState(3)
   const [parties, setParties] = useState([])
   const [partieActuelle, setPartieActuelle] = useState(0)
-  const [scores, setScores] = useState({ equipe1: '', equipe2: '' })
   const [showArbitreLogin, setShowArbitreLogin] = useState(false)
   const [archives, setArchives] = useState([])
   const [expandedArchive, setExpandedArchive] = useState(null)

--- a/src/views/EquipesView.jsx
+++ b/src/views/EquipesView.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
-import { Input } from '@/components/ui/input.jsx'
 import { Play, Plus, Trash2, Trophy } from 'lucide-react'
 
 export default function EquipesView({

--- a/src/views/PartiesView.jsx
+++ b/src/views/PartiesView.jsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import PartieCard from '@/components/PartieCard.jsx'
-import { Play, Trophy } from 'lucide-react'
+import { Play } from 'lucide-react'
 
 export default function PartiesView({
   setCurrentView,


### PR DESCRIPTION
## Summary
- remove unused imports in App.jsx and update HomeView usage
- drop unused Input in EquipesView
- drop unused Trophy import in PartiesView
- adjust unused state variables

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684404ec7e5083238a84df463e4f9d63