### PR TITLE
Fix Arbitre popup color

### DIFF
--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -10,7 +10,7 @@ function Card({
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "flex flex-col gap-6 rounded-xl border py-6 shadow-sm bg-[var(--card)] text-[var(--card-foreground)]",
         className
       )}
       {...props} />


### PR DESCRIPTION
## Summary
- ensure Card components use the theme card color

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_684409be5aac8323a27aee743dcc41ec