### PR TITLE
Add Supabase setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ Create a `petanque_data` table in Supabase with the columns `key` (text,
 primary key) and `value` (jsonb). The application stores its state in this table
 using keys such as `joueurs`, `concours`, `equipes`, `parties` and `archives`.
 
+### Supabase setup
+
+If you are starting from scratch, run the following SQL commands in the
+Supabase SQL editor to create the table and insert initial data:
+
+```sql
+CREATE TABLE petanque_data (
+  key   text PRIMARY KEY,
+  value jsonb
+);
+
+-- Example insertion
+INSERT INTO petanque_data(key, value)
+VALUES ('joueurs', '[{"id":1,"pseudo":"Alice"}]')
+ON CONFLICT (key)
+  DO UPDATE SET value = EXCLUDED.value;
+```
+
+Provide the project with your Supabase credentials via environment variables in
+a `.env` file:
+
+```
+VITE_SUPABASE_URL=<your Supabase URL>
+VITE_SUPABASE_ANON_KEY=<your anonymous key>
+```
+
 ## Setup
 
 Install dependencies and start the development server:

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -3,4 +3,8 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error('Supabase URL and anonymous key must be provided via environment variables')
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- document how to create the `petanque_data` table and insert initial rows
- validate env vars for the Supabase client

## Testing
- `pnpm run lint` *(fails: A config object is using the "root" key)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68442fdbdf248323991379bc0c3d7003