### PR TITLE
Ignore build artifacts in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,4 +7,9 @@ const compat = new FlatCompat({
   recommendedConfig: js.configs.recommended
 })
 
-export default compat.config(eslintConfig)
+export default [
+  ...compat.config(eslintConfig),
+  {
+    ignores: ['dist/**', 'node_modules/**']
+  }
+]


### PR DESCRIPTION
## Summary
- ignore `dist` and `node_modules` in the ESLint flat config

## Testing
- `pnpm lint` *(fails: Parsing error in `src/remoteStorage.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6844407418c08323b55b7602927ce732