### PR TITLE
Ignore dist in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,4 +12,4 @@ export default [
   {
     ignores: ['dist/**', 'node_modules/**']
   }
-]
+];

--- a/src/remoteStorage.js
+++ b/src/remoteStorage.js
@@ -39,20 +39,3 @@ export function subscribeToRemoteData(key, callback) {
     supabase.removeChannel(channel)
   }
 }
-
-export function subscribeToRemoteData(key, callback) {
-  const channel = supabase
-    .channel(`petanque-data-${key}`)
-    .on(
-      'postgres_changes',
-      { event: '*', schema: 'public', table: 'petanque_data', filter: `key=eq.${key}` },
-      (payload) => {
-        callback(payload.new ? payload.new.value : null)
-      }
-    )
-    .subscribe()
-
-  return () => {
-    supabase.removeChannel(channel)
-  }
-}


### PR DESCRIPTION
## Summary
- fix duplicate `subscribeToRemoteData` implementation
- ensure eslint config ignores `dist` and `node_modules`

## Testing
- `pnpm lint`
- `pnpm test`
- `npx eslint dist/bad.js`

------
https://chatgpt.com/codex/tasks/task_e_684455171688832383130ea149e9fda6