### PR TITLE
Add manual team creation and admin start/resume

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1044,7 +1044,17 @@ function App() {
     case 'joueur':
       return <JoueurView setCurrentView={setCurrentView} concours={concours} equipes={equipes} />
     case 'admin':
-      return <AdminView setCurrentView={setCurrentView} setIsArbitre={setIsArbitre} concours={concours} equipes={equipes} parties={parties} partieActuelle={partieActuelle} />
+      return (
+        <AdminView
+          setCurrentView={setCurrentView}
+          setIsArbitre={setIsArbitre}
+          concours={concours}
+          equipes={equipes}
+          parties={parties}
+          partieActuelle={partieActuelle}
+          commencerParties={commencerParties}
+        />
+      )
     case 'joueurs':
       return renderJoueursView()
     case 'concours':

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Crown, Users, Trophy, Play, Archive } from 'lucide-react'
 
-function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, partieActuelle }) {
+function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, partieActuelle, commencerParties }) {
 
   return (
     <div className="min-h-screen bg-background p-4">
@@ -62,10 +62,21 @@ function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, p
 
                   )}
                 </div>
-                {equipes.length > 0 && parties.length > 0 && (
-                  <Button onClick={() => setCurrentView('parties')} className="w-full" variant="outline">
+                {equipes.length > 0 && (
+                  <Button
+                    onClick={() => {
+                      if (parties.length === 0) {
+                        commencerParties()
+                      } else {
+                        setCurrentView('parties')
+                      }
+                    }}
+                    className="w-full"
+                    variant="outline"
+                    disabled={parties.length === 0 && equipes.length < 2}
+                  >
                     <Play className="w-4 h-4 mr-2" />
-                    Reprendre les parties
+                    {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
                   </Button>
                 )}
               </div>


### PR DESCRIPTION
## Summary
- support manual team creation alongside automatic mode
- generate automatic teams only for remaining players
- allow starting/resuming matches from admin home

## Testing
- `pnpm run lint`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_68445d918b6083239a1843382b2a4d04