### PR TITLE
Fix concours persistence and archiving

### DIFF
--- a/src/views/ConcoursView.jsx
+++ b/src/views/ConcoursView.jsx
@@ -16,9 +16,9 @@ export default function ConcoursView({
   creerConcours,
   concours,
 }) {
-  const handleCreerConcours = () => {
+  const handleCreerConcours = async () => {
     if (nomConcours.trim()) {
-      creerConcours(nomConcours.trim(), dateConcours, nombreParties)
+      await creerConcours(nomConcours.trim(), dateConcours, nombreParties)
       setCurrentView('admin')
     }
   }

--- a/src/views/EquipesView.jsx
+++ b/src/views/EquipesView.jsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Play, Plus, Trash2, Trophy } from 'lucide-react'
+import { saveRemoteData } from '../remoteStorage.js'
 
 export default function EquipesView({
   joueurs,
@@ -21,7 +22,7 @@ export default function EquipesView({
     (j) => !j.arbitre && !equipes.some((e) => e.joueurs.includes(j.pseudo))
   )
 
-  const formerEquipesAleatoires = () => {
+  const formerEquipesAleatoires = async () => {
     if (joueursRestants.length < 2) {
       alert('Il faut au moins 2 joueurs (non arbitres) pour former des équipes')
       return
@@ -34,35 +35,41 @@ export default function EquipesView({
       ;[joueursAleatoires[i], joueursAleatoires[j]] = [joueursAleatoires[j], joueursAleatoires[i]]
     }
     for (let i = 0; i < nombreEquipes; i++) {
-      nouvellesEquipes.push({ id: Date.now().toString() + i, nom: `Équipe ${equipes.length + i + 1}`, joueurs: [], victoires: 0, points: 0, partiesJouees: 0 })
+      nouvellesEquipes.push({ id: crypto.randomUUID(), nom: `Équipe ${equipes.length + i + 1}`, joueurs: [], victoires: 0, points: 0, partiesJouees: 0 })
     }
     joueursAleatoires.forEach((joueur, index) => {
       const equipeIndex = index % nombreEquipes
       nouvellesEquipes[equipeIndex].joueurs.push(joueur.pseudo)
     })
-    setEquipes([...equipes, ...nouvellesEquipes])
+    const updated = [...equipes, ...nouvellesEquipes]
+    setEquipes(updated)
+    await saveRemoteData('equipes', updated)
   }
 
-  const supprimerEquipe = (id) => {
+  const supprimerEquipe = async (id) => {
     if (confirm('Êtes-vous sûr de vouloir supprimer cette équipe ?')) {
-      setEquipes(equipes.filter((e) => e.id !== id))
+      const updated = equipes.filter((e) => e.id !== id)
+      setEquipes(updated)
+      await saveRemoteData('equipes', updated)
     }
   }
 
-  const ajouterEquipeManuellement = () => {
+  const ajouterEquipeManuellement = async () => {
     if (nomEquipe.trim() && joueursSelectionnes.length > 0) {
       const joueursEquipe = joueursSelectionnes.map(
         (id) => joueurs.find((j) => j.id === id).pseudo
       )
       const nouvelleEquipe = {
-        id: Date.now().toString(),
+        id: crypto.randomUUID(),
         nom: nomEquipe.trim(),
         joueurs: joueursEquipe,
         victoires: 0,
         points: 0,
         partiesJouees: 0,
       }
-      setEquipes([...equipes, nouvelleEquipe])
+      const updated = [...equipes, nouvelleEquipe]
+      setEquipes(updated)
+      await saveRemoteData('equipes', updated)
       setNomEquipe('')
       setJoueursSelectionnes([])
     }


### PR DESCRIPTION
## Summary
- persist newly created concours immediately
- persist concour termination status
- save parties and equipe updates right away
- archive concours reliably and remove old data
- redirect clients when a concours gets archived
- update ConcoursView helper

## Testing
- `pnpm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844627cc76083239f4d15fe9c04f16a