### PR TITLE
Implement persistData helper for Supabase

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,8 @@ import {
   insertRow,
   updateRow,
   deleteRow,
-  subscribeToTable
+  subscribeToTable,
+  persistData
 } from './remoteStorage.js'
 import { Users, Trophy, Play, Settings, Archive, Crown, Plus, Edit, Trash2, Medal } from 'lucide-react'
 import './App.css'

--- a/src/views/EquipesView.jsx
+++ b/src/views/EquipesView.jsx
@@ -5,7 +5,7 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Input } from '@/components/ui/input.jsx'
 import { Checkbox } from '@/components/ui/checkbox.jsx'
 import { Play, Plus, Trash2, Trophy } from 'lucide-react'
-import { saveRemoteData } from '../remoteStorage.js'
+import { persistData } from '../remoteStorage.js'
 
 export default function EquipesView({
   joueurs,
@@ -43,14 +43,14 @@ export default function EquipesView({
     })
     const updated = [...equipes, ...nouvellesEquipes]
     setEquipes(updated)
-    await saveRemoteData('equipes', updated)
+    await persistData('equipes', updated)
   }
 
   const supprimerEquipe = async (id) => {
     if (confirm('Êtes-vous sûr de vouloir supprimer cette équipe ?')) {
       const updated = equipes.filter((e) => e.id !== id)
       setEquipes(updated)
-      await saveRemoteData('equipes', updated)
+      await persistData('equipes', updated)
     }
   }
 
@@ -69,7 +69,7 @@ export default function EquipesView({
       }
       const updated = [...equipes, nouvelleEquipe]
       setEquipes(updated)
-      await saveRemoteData('equipes', updated)
+      await persistData('equipes', updated)
       setNomEquipe('')
       setJoueursSelectionnes([])
     }


### PR DESCRIPTION
## Summary
- add new `persistData` function to remote storage utilities
- import `persistData` in App and EquipesView
- replace old `saveRemoteData` calls

## Testing
- `pnpm run lint`
- `pnpm run test`


------
https://chatgpt.com/codex/tasks/task_e_684473622b2483239b9c9314c218f130