### PR TITLE
Add terminate contest button in AdminView

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1128,6 +1128,10 @@ function App() {
           parties={parties}
           partieActuelle={partieActuelle}
           commencerParties={commencerParties}
+          setConcours={setConcours}
+          setEquipes={setEquipes}
+          setParties={setParties}
+          setPartieActuelle={setPartieActuelle}
         />
       )
     case 'joueurs':

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -2,8 +2,34 @@
 import { Button } from '@/components/ui/button.jsx'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Crown, Users, Trophy, Play, Archive } from 'lucide-react'
+import { deleteRow } from '../remoteStorage.js'
 
-function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, partieActuelle, commencerParties }) {
+function AdminView({
+  setCurrentView,
+  setIsArbitre,
+  concours,
+  equipes,
+  parties,
+  partieActuelle,
+  commencerParties,
+  setConcours,
+  setEquipes,
+  setParties,
+  setPartieActuelle,
+}) {
+
+  const handleTerminate = async () => {
+    if (confirm('Êtes-vous sûr de vouloir terminer ce concours ?')) {
+      await deleteRow('concours', concours.id)
+      equipes.forEach((e) => deleteRow('equipes', e.id))
+      parties.forEach((p) => deleteRow('parties', p.id))
+      setConcours(null)
+      setEquipes([])
+      setParties([])
+      setPartieActuelle(0)
+      setCurrentView('admin')
+    }
+  }
 
   return (
     <div className="min-h-screen bg-background p-4">
@@ -73,13 +99,16 @@ function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, p
                     }}
                     className="w-full"
                     variant="outline"
-                    disabled={parties.length === 0 && equipes.length < 2}
-                  >
-                    <Play className="w-4 h-4 mr-2" />
-                    {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
-                  </Button>
-                )}
-              </div>
+                  disabled={parties.length === 0 && equipes.length < 2}
+                >
+                  <Play className="w-4 h-4 mr-2" />
+                  {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
+                </Button>
+                <Button variant="destructive" onClick={handleTerminate} className="w-full">
+                  Terminer le concours
+                </Button>
+              )}
+            </div>
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- allow administrators to terminate a contest directly from `AdminView`
- update props passed to `AdminView`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68447bcdfaf0832397b7ba18424ac30d