### PR TITLE
Add parties button in concours view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -685,7 +685,25 @@ function App() {
                   <Badge variant="outline">
                     {concours.statut === 'en_cours' ? 'En cours' : 'Terminé'}
                   </Badge>
-                  
+
+                  {equipes.length > 0 && (
+                    <Button
+                      onClick={() => {
+                        if (parties.length === 0) {
+                          commencerParties()
+                        } else {
+                          setCurrentView('parties')
+                        }
+                      }}
+                      className="w-full"
+                      variant="outline"
+                      disabled={parties.length === 0 && equipes.length < 2}
+                    >
+                      <Play className="w-4 h-4 mr-2" />
+                      {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
+                    </Button>
+                  )}
+
                   {concours.statut === 'en_cours' && (
                     <Button
                       variant="destructive"


### PR DESCRIPTION
## Summary
- allow starting/resuming matches from the concours screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68447bd0cd288323ac3e702cc4514267