### PR TITLE
Fix early contest termination and admin controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -223,6 +223,20 @@ function App() {
 
     setCurrentView('parties')
   }
+  const terminerConcours = async () => {
+    if (!concours) return
+    if (confirm("Êtes-vous sûr de vouloir terminer ce concours ?")) {
+      await deleteRow("concours", concours.id)
+      equipes.forEach(e => deleteRow("equipes", e.id))
+      parties.forEach(p => deleteRow("parties", p.id))
+      setConcours(null)
+      setEquipes([])
+      setParties([])
+      setPartieActuelle(0)
+      setCurrentView("admin")
+    }
+  }
+
 
   const enregistrerScore = async (partieId, score1, score2) => {
     const partiesUpdated = parties.map(partie => {
@@ -689,13 +703,7 @@ function App() {
                   {concours.statut === 'en_cours' && (
                     <Button
                       variant="destructive"
-                      onClick={async () => {
-                        if (confirm('Êtes-vous sûr de vouloir terminer ce concours ?')) {
-                          const updated = { ...concours, statut: 'termine' }
-                          setConcours(updated)
-                          await persistData('concours', updated)
-                        }
-                      }}
+                      onClick={terminerConcours}
                       className="w-full"
                     >
                       Terminer le concours

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -62,7 +62,16 @@ function AdminView({ setCurrentView, setIsArbitre, concours, equipes, parties, p
 
                   )}
                 </div>
-                {equipes.length > 0 && (
+                {equipes.length === 0 ? (
+                  <Button
+                    onClick={() => setCurrentView('equipes')}
+                    className="w-full"
+                    variant="outline"
+                  >
+                    <Play className="w-4 h-4 mr-2" />
+                    Créer les équipes
+                  </Button>
+                ) : (
                   <Button
                     onClick={() => {
                       if (parties.length === 0) {


### PR DESCRIPTION
## Summary
- add a helper to fully remove a contest when it is terminated early
- call the new helper in Concours view instead of just updating status
- show **Créer les équipes** when no team exists in Admin view

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684479b5ffec8323ab341dd2d84d1fd9