### PR TITLE
Update team creation UI when no contest

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -864,16 +864,17 @@ function App() {
             <Play className="w-6 h-6 text-primary" />
           </div>
 
-          {!concours ? (
+          {!concours && (
             <Card>
               <CardContent className="pt-6">
                 <p className="text-center text-muted-foreground">
-                  Créez d'abord un concours pour gérer les équipes
+                  Aucun concours en cours
                 </p>
               </CardContent>
             </Card>
-          ) : (
-            <>
+          )}
+
+          <>
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center">
@@ -974,7 +975,7 @@ function App() {
                 </CardContent>
               </Card>
 
-              {equipes.length > 0 && (
+              {concours && equipes.length > 0 && (
                 <Card>
                   <CardHeader>
                     <CardTitle>Actions</CardTitle>

--- a/src/views/EquipesView.jsx
+++ b/src/views/EquipesView.jsx
@@ -83,14 +83,14 @@ export default function EquipesView({
           <h1 className="text-xl font-bold">Gestion des Équipes</h1>
           <Play className="w-6 h-6 text-primary" />
         </div>
-        {!concours ? (
+        {!concours && (
           <Card>
             <CardContent className="pt-6">
-              <p className="text-center text-muted-foreground">Créez d'abord un concours pour gérer les équipes</p>
+              <p className="text-center text-muted-foreground">Aucun concours en cours</p>
             </CardContent>
           </Card>
-        ) : (
-          <>
+        )}
+        <>
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center">
@@ -189,7 +189,7 @@ export default function EquipesView({
                 )}
               </CardContent>
             </Card>
-            {equipes.length > 0 && (
+            {concours && equipes.length > 0 && (
               <Card>
                 <CardHeader>
                   <CardTitle>Actions</CardTitle>


### PR DESCRIPTION
## Summary
- keep manual and automatic team creation sections visible even when no contest is running
- display a simple "Aucun concours en cours" message when no contest exists
- show start-games actions only if a contest exists

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6844805fccfc8323bf142025bb4a87ba