### PR TITLE
Fix concours card buttons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -700,7 +700,16 @@ function App() {
                     {concours.statut === 'en_cours' ? 'En cours' : 'Terminé'}
                   </Badge>
 
-                  {equipes.length > 0 && (
+                  {equipes.length === 0 ? (
+                    <Button
+                      onClick={() => setCurrentView('equipes')}
+                      className="w-full"
+                      variant="outline"
+                    >
+                      <Play className="w-4 h-4 mr-2" />
+                      Créer les équipes
+                    </Button>
+                  ) : (
                     <Button
                       onClick={() => {
                         if (parties.length === 0) {
@@ -718,15 +727,13 @@ function App() {
                     </Button>
                   )}
 
-                  {concours.statut === 'en_cours' && (
-                    <Button
-                      variant="destructive"
-                      onClick={terminerConcours}
-                      className="w-full"
-                    >
-                      Terminer le concours
-                    </Button>
-                  )}
+                  <Button
+                    variant="destructive"
+                    onClick={terminerConcours}
+                    className="w-full"
+                  >
+                    Terminer le concours
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/src/views/AdminView.jsx
+++ b/src/views/AdminView.jsx
@@ -98,7 +98,6 @@ function AdminView({
                     Créer les équipes
                   </Button>
                 ) : (
-                  <>
                   <Button
                     onClick={() => {
                       if (parties.length === 0) {
@@ -109,17 +108,16 @@ function AdminView({
                     }}
                     className="w-full"
                     variant="outline"
-                  disabled={parties.length === 0 && equipes.length < 2}
-                >
-                  <Play className="w-4 h-4 mr-2" />
-                  {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
-                </Button>
+                    disabled={parties.length === 0 && equipes.length < 2}
+                  >
+                    <Play className="w-4 h-4 mr-2" />
+                    {parties.length === 0 ? 'Commencer les parties' : 'Reprendre les parties'}
+                  </Button>
+                )}
                 <Button variant="destructive" onClick={handleTerminate} className="w-full">
                   Terminer le concours
                 </Button>
-                  </>
-              )}
-            </div>
+              </div>
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary
- show both team creation and termination options consistently
- align concours card behavior across AdminView and concours menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684481404bf083239f8473fc1689567c